### PR TITLE
Upgrade watchdog to 0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,8 @@ extra_dependencies = {
     ],
 
     "watch": [
-        "watchdog>=0.8,<0.9",
-        "watchdog_gevent==0.1",
+        "watchdog==0.10.*",
+        "watchdog_gevent==0.1.*",
     ],
 }
 


### PR DESCRIPTION
To get rid of DeprecationWarning

```
  /usr/local/lib/python3.8/site-packages/watchdog/utils/bricks.py:175: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    class OrderedSet(collections.MutableSet):
```